### PR TITLE
Use FileSystem

### DIFF
--- a/StellarEmpires/Infrastructure/PlanetStore/planets.json
+++ b/StellarEmpires/Infrastructure/PlanetStore/planets.json
@@ -1,0 +1,10 @@
+[
+  {
+    "Name": "Earth",
+    "IsColonized": false,
+    "ColonizedBy": null,
+    "ColonizedAt": null,
+    "DomainEvents": [],
+    "Id": "3fa85f64-5717-4562-b3fc-2c963f66afa6"
+  }
+]

--- a/StellarEmpires/Program.cs
+++ b/StellarEmpires/Program.cs
@@ -3,6 +3,7 @@ using StellarEmpires.Domain.Services;
 using StellarEmpires.Infrastructure;
 using StellarEmpires.Infrastructure.EventStore;
 using StellarEmpires.Infrastructure.PlanetStore;
+using System.IO.Abstractions;
 using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -18,6 +19,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 builder.Services.AddMemoryCache();
 
+builder.Services.AddScoped<IFileSystem, FileSystem>();
 builder.Services.AddScoped<IEventStore, FileEventStore>();
 builder.Services.AddScoped<IPlanetStore, FilePlanetStore>();
 builder.Services.AddScoped<IPlanetStateRetriever, PlanetStateRetriever>();

--- a/StellarEmpires/StellarEmpires.csproj
+++ b/StellarEmpires/StellarEmpires.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="MediatR" Version="12.4.1" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
+    <PackageReference Include="System.IO.Abstractions" Version="21.1.3" />
 	  <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
 

--- a/StellarEmpiresTests/Infrastructure/EventStore/FileEventStoreTests.cs
+++ b/StellarEmpiresTests/Infrastructure/EventStore/FileEventStoreTests.cs
@@ -3,23 +3,23 @@ using StellarEmpires.Events;
 using StellarEmpires.Helpers;
 using StellarEmpires.Infrastructure.EventStore;
 using StellarEmpires.Tests.Mocks;
+using System.IO.Abstractions.TestingHelpers;
 
 namespace StellarEmpires.Tests.Infrastructure.EventStore;
 
 [TestFixture]
 public class FileEventStoreTests
 {
+	private MockFileSystem _fileSystem;
 	private FileEventStore _eventStore;
-	private string _baseDirectory;
 
 	private DateTime _utcNow;
 
 	[SetUp]
 	public void Setup()
 	{
-		_baseDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Infrastructure", "EventStore");
-
-		_eventStore = new FileEventStore();
+		_fileSystem = new MockFileSystem();
+		_eventStore = new FileEventStore(_fileSystem);
 
 		_utcNow = new DateTime(2024, 11, 7, 0, 0, 0, DateTimeKind.Utc);
 		DateTimeProvider.SetUtcNow(() => _utcNow);
@@ -29,17 +29,10 @@ public class FileEventStoreTests
 	public void Teardown()
 	{
 		DateTimeProvider.ResetUtcNow();
-
-		var files = Directory.GetFiles(_baseDirectory, "events-*.json");
-
-		foreach (var file in files)
-		{
-			File.Delete(file);
-		}
 	}
 
 	[Test]
-	public async Task SaveEventAsync_ShouldSaveEventToFile()
+	public async Task SaveEventAsync_ShouldCreateDirectoryAndFile_WhenEventIsSaved()
 	{
 		// Arrange
 		var domainEvent = new MockDomainEvent{ EntityId = Guid.NewGuid() };
@@ -48,12 +41,10 @@ public class FileEventStoreTests
 		await _eventStore.SaveEventAsync<MockEntity>(domainEvent);
 
 		// Assert
-		Assert.That(Directory.Exists(_baseDirectory), Is.True);
+		var filePath = _fileSystem.Path.Combine("Infrastructure", "EventStore", "events-mockentity.json");
+		Assert.That(_fileSystem.FileExists(filePath), Is.True);
 
-		var filePath = Path.Combine(_baseDirectory, "events-mockentity.json");
-		Assert.That(File.Exists(filePath), Is.True);
-
-		var fileContent = await File.ReadAllTextAsync(filePath);
+		var fileContent = await _fileSystem.File.ReadAllTextAsync(filePath);
 		Assert.That(fileContent, Does.Contain("OccurredOn"));
 		Assert.That(fileContent, Does.Contain("2024-11-07T00:00:00Z"));
 	}
@@ -72,10 +63,10 @@ public class FileEventStoreTests
 		await _eventStore.SaveEventAsync<Planet>(domainEvent);
 
 		// Assert
-		var filePath = Path.Combine(_baseDirectory, "events-planet.json");
-		Assert.That(File.Exists(filePath), Is.True, "The event file should be created.");
+		var filePath = _fileSystem.Path.Combine("Infrastructure", "EventStore", "events-planet.json");
+		Assert.That(_fileSystem.FileExists(filePath), Is.True);
 
-		var fileContent = await File.ReadAllTextAsync(filePath);
+		var fileContent = await _fileSystem.File.ReadAllTextAsync(filePath);
 
 		// Check serialization for specific properties
 		var expectedEventType = nameof(PlanetColonizedDomainEvent);
@@ -112,6 +103,27 @@ public class FileEventStoreTests
 			Assert.That(((MockDomainEvent)retrievedEvent).EntityId, Is.EqualTo(entityId));
 			Assert.That(((MockDomainEvent)retrievedEvent).OccurredOn, Is.EqualTo(_utcNow));
 		}
+	}
+
+	[Test]
+	public async Task GetEventsAsync_ShouldReturnEmptyList_WhenFileDoesNotExist()
+	{
+		// Act
+		var events = await _eventStore.GetEventsAsync<Planet>(Guid.NewGuid());
+
+		// Assert
+		Assert.That(events, Is.Empty);
+	}
+
+	[Test]
+	public async Task GetEventsAsync_ShouldCreateBaseDirectory_WhenNotExisting()
+	{
+		// Act
+		await _eventStore.GetEventsAsync<Planet>(Guid.NewGuid());
+
+		// Assert
+		var baseDirPath = _fileSystem.Path.Combine("Infrastructure", "EventStore");
+		Assert.That(_fileSystem.Directory.Exists(baseDirPath), Is.True);
 	}
 
 	[Test]

--- a/StellarEmpiresTests/StellarEmpires.Tests.csproj
+++ b/StellarEmpiresTests/StellarEmpires.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="NUnit" Version="3.14.0" />
     <PackageReference Include="NUnit.Analyzers" Version="3.9.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="21.1.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Use predefined list of planets in Infrastructure > PlanetStore to define the initial state of planets.

Use `FileSystem` from `System.IO.Abstractions` to manage the paths/files and allow to mock them easily.