### PR TITLE
Save latest planet state via IPlanetStore

### DIFF
--- a/StellarEmpires/Application/Commands/CreatePlanetCommand.cs
+++ b/StellarEmpires/Application/Commands/CreatePlanetCommand.cs
@@ -1,0 +1,10 @@
+﻿namespace StellarEmpires.Application.Commands;
+
+public record CreatePlanetCommand
+{
+	public required Guid Id { get; init; }
+	public required string Name { get; init; }
+	public required bool IsColonized { get; init; }
+	public Guid? ColonizedBy { get; init; }
+	public DateTime? ColonizedAt { get; init; }
+}

--- a/StellarEmpires/Application/Commands/CreatePlanetCommandHandler.cs
+++ b/StellarEmpires/Application/Commands/CreatePlanetCommandHandler.cs
@@ -1,0 +1,36 @@
+﻿using StellarEmpires.Domain.Models;
+using StellarEmpires.Infrastructure.EventStore;
+using StellarEmpires.Infrastructure.PlanetStore;
+
+namespace StellarEmpires.Application.Commands;
+
+public class CreatePlanetCommandHandler : ICreatePlanetCommandHandler
+{
+	private readonly IPlanetStore _planetStore;
+	private readonly IEventStore _eventStore;
+
+	public CreatePlanetCommandHandler(IPlanetStore planetStore, IEventStore eventStore)
+	{
+		_planetStore = planetStore;
+		_eventStore = eventStore;
+	}
+
+	public async Task CreatePlanetAsync(CreatePlanetCommand command)
+	{
+		var existingPlanet = await _planetStore.GetPlanetByIdAsync(command.Id);
+		if (existingPlanet != null)
+		{
+			throw new InvalidOperationException("Planet with the same ID already exists.");
+		}
+
+		var newPlanet = Planet.Create(
+			command.Id,
+			command.Name,
+			command.IsColonized,
+			command.ColonizedBy,
+			command.ColonizedAt
+		);
+
+		await _eventStore.SaveEventAsync<Planet>(newPlanet.DomainEvents.Last());
+	}
+}

--- a/StellarEmpires/Application/Commands/ICreatePlanetCommandHandler.cs
+++ b/StellarEmpires/Application/Commands/ICreatePlanetCommandHandler.cs
@@ -1,0 +1,6 @@
+﻿namespace StellarEmpires.Application.Commands;
+
+public interface ICreatePlanetCommandHandler
+{
+	Task CreatePlanetAsync(CreatePlanetCommand command);
+}

--- a/StellarEmpires/Events/PlanetCreatedDomainEvent.cs
+++ b/StellarEmpires/Events/PlanetCreatedDomainEvent.cs
@@ -1,0 +1,14 @@
+using StellarEmpires.Helpers;
+
+namespace StellarEmpires.Events;
+
+public sealed record PlanetCreatedDomainEvent : IDomainEvent
+{
+	public string EventType => nameof(PlanetCreatedDomainEvent);
+
+	public Guid Id => Guid.NewGuid();
+	public DateTime OccurredOn { get; init; } = DateTimeProvider.UtcNow;
+
+	public required Guid EntityId { get; init; }
+	public required string PlanetName { get; init; }
+}

--- a/StellarEmpires/Infrastructure/EventStore/DomainEventJsonConverter.cs
+++ b/StellarEmpires/Infrastructure/EventStore/DomainEventJsonConverter.cs
@@ -10,7 +10,8 @@ public class DomainEventJsonConverter : JsonConverter<IDomainEvent>
 	{
 		{ nameof(MockDomainEvent), typeof(MockDomainEvent) },
 		{ nameof(PlanetColonizedDomainEvent), typeof(PlanetColonizedDomainEvent) },
-		{ nameof(PlanetRenamedDomainEvent), typeof(PlanetRenamedDomainEvent) }
+		{ nameof(PlanetRenamedDomainEvent), typeof(PlanetRenamedDomainEvent) },
+		{ nameof(PlanetCreatedDomainEvent), typeof(PlanetCreatedDomainEvent) }
 	};
 
 

--- a/StellarEmpires/Infrastructure/EventStore/FileEventStore.cs
+++ b/StellarEmpires/Infrastructure/EventStore/FileEventStore.cs
@@ -1,4 +1,6 @@
-﻿using StellarEmpires.Events;
+﻿using StellarEmpires.Domain.Models;
+using StellarEmpires.Events;
+using StellarEmpires.Infrastructure.PlanetStore;
 using System.IO.Abstractions;
 using System.Text.Json;
 
@@ -7,12 +9,14 @@ namespace StellarEmpires.Infrastructure.EventStore;
 public class FileEventStore : IEventStore
 {
 	private readonly IFileSystem _fileSystem;
+	private readonly IPlanetStore _planetStore;
 	private readonly string BaseDirectory;
 	private readonly JsonSerializerOptions _jsonOptions;
 
-	public FileEventStore(IFileSystem fileSystem)
+	public FileEventStore(IFileSystem fileSystem, IPlanetStore planetStore)
 	{
 		_fileSystem = fileSystem;
+		_planetStore = planetStore;
 		BaseDirectory = _fileSystem.Path.Combine("Infrastructure", "EventStore");
 		_jsonOptions = new JsonSerializerOptions
 		{
@@ -30,6 +34,18 @@ public class FileEventStore : IEventStore
 
 		var json = JsonSerializer.Serialize(allEvents, _jsonOptions);
 		await _fileSystem.File.WriteAllTextAsync(filePath, json);
+
+		// Save the latest state of the planet
+		if (typeof(TEntity) == typeof(Planet))
+		{
+			var planet = await _planetStore.GetPlanetByIdAsync(domainEvent.EntityId);
+
+			if (planet != null)
+			{
+				planet.Apply(domainEvent);
+				await _planetStore.SavePlanetAsync(planet);
+			}
+		}
 	}
 
 	public async Task<IEnumerable<IDomainEvent>> GetEventsAsync<TEntity>(Guid entityId)

--- a/StellarEmpires/Infrastructure/PlanetStore/FilePlanetStore.cs
+++ b/StellarEmpires/Infrastructure/PlanetStore/FilePlanetStore.cs
@@ -36,7 +36,6 @@ public class FilePlanetStore : IPlanetStore
 		if (existingPlanet != null)
 		{
 			planets.Remove(existingPlanet);
-			//throw new InvalidOperationException("Planet already exists in the list.");
 		}
 
 		planets.Add(planet);

--- a/StellarEmpires/Infrastructure/PlanetStore/FilePlanetStore.cs
+++ b/StellarEmpires/Infrastructure/PlanetStore/FilePlanetStore.cs
@@ -35,7 +35,8 @@ public class FilePlanetStore : IPlanetStore
 
 		if (existingPlanet != null)
 		{
-			throw new InvalidOperationException("Planet already exists in the list.");
+			planets.Remove(existingPlanet);
+			//throw new InvalidOperationException("Planet already exists in the list.");
 		}
 
 		planets.Add(planet);

--- a/StellarEmpires/WebApi/v1/PlanetsController.cs
+++ b/StellarEmpires/WebApi/v1/PlanetsController.cs
@@ -76,7 +76,7 @@ public class PlanetsController : ControllerBase
 			return BadRequest("Planet with the same ID already exists.");
 		}
 
-		var newPlanet = new Planet(
+		var newPlanet = Planet.Create(
 			request.Id,
 			request.Name,
 			request.IsColonized,

--- a/StellarEmpiresTests/Applications/Commands/ColonizePlanetCommandHandlerTests.cs
+++ b/StellarEmpiresTests/Applications/Commands/ColonizePlanetCommandHandlerTests.cs
@@ -42,7 +42,7 @@ public class ColonizePlanetCommandHandlerTests
 		// Arrange
 		var planetId = Guid.NewGuid();
 		var playerId = Guid.NewGuid();
-		var planet = new Planet(planetId, "Test Planet", false, null, null);
+		var planet = Planet.Create(planetId, "Test Planet", false, null, null);
 
 		_planetStateRetrieverMock
 			.Setup(r => r.GetCurrentStateAsync(planetId))
@@ -82,7 +82,7 @@ public class ColonizePlanetCommandHandlerTests
 		// Arrange
 		var planetId = Guid.NewGuid();
 		var playerId = Guid.NewGuid();
-		var planet = new Planet(planetId, "Test Planet", true, playerId, _utcNow);
+		var planet = Planet.Create(planetId, "Test Planet", true, playerId, _utcNow);
 
 		_planetStateRetrieverMock
 			.Setup(r => r.GetCurrentStateAsync(planetId))

--- a/StellarEmpiresTests/Applications/Commands/CreatePlanetCommandHandlerTests.cs
+++ b/StellarEmpiresTests/Applications/Commands/CreatePlanetCommandHandlerTests.cs
@@ -1,0 +1,74 @@
+using Moq;
+using NUnit.Framework;
+using StellarEmpires.Application.Commands;
+using StellarEmpires.Domain.Models;
+using StellarEmpires.Events;
+using StellarEmpires.Infrastructure.EventStore;
+using StellarEmpires.Infrastructure.PlanetStore;
+using System;
+using System.Threading.Tasks;
+
+namespace StellarEmpires.Tests.Application.Commands;
+
+[TestFixture]
+public class CreatePlanetCommandHandlerTests
+{
+    private Mock<IPlanetStore> _mockPlanetStore;
+    private Mock<IEventStore> _mockEventStore;
+    private CreatePlanetCommandHandler _handler;
+
+    [SetUp]
+    public void Setup()
+    {
+        _mockPlanetStore = new Mock<IPlanetStore>();
+        _mockEventStore = new Mock<IEventStore>();
+        _handler = new CreatePlanetCommandHandler(_mockPlanetStore.Object, _mockEventStore.Object);
+    }
+
+    [Test]
+    public void CreatePlanetAsync_ShouldThrowException_WhenPlanetWithSameIdAlreadyExists()
+    {
+        // Arrange
+        var command = new CreatePlanetCommand
+        {
+            Id = Guid.NewGuid(),
+            Name = "Earth",
+            IsColonized = false,
+            ColonizedBy = null,
+            ColonizedAt = null
+        };
+
+        _mockPlanetStore
+            .Setup(store => store.GetPlanetByIdAsync(command.Id))
+            .ReturnsAsync(Planet.Create(command.Id, command.Name, command.IsColonized, command.ColonizedBy, command.ColonizedAt));
+
+        // Act & Assert
+        var ex = Assert.ThrowsAsync<InvalidOperationException>(async () => await _handler.CreatePlanetAsync(command));
+        Assert.That(ex.Message, Is.EqualTo("Planet with the same ID already exists."));
+    }
+
+    [Test]
+    public async Task CreatePlanetAsync_ShouldCreateNewPlanetAndSaveEvent()
+    {
+        // Arrange
+        var command = new CreatePlanetCommand
+        {
+            Id = Guid.NewGuid(),
+            Name = "Earth",
+            IsColonized = false,
+            ColonizedBy = null,
+            ColonizedAt = null
+        };
+
+        _mockPlanetStore
+            .Setup(store => store.GetPlanetByIdAsync(command.Id))
+            .ReturnsAsync((Planet?)null);
+
+        // Act
+        await _handler.CreatePlanetAsync(command);
+
+        // Assert
+        _mockEventStore.Verify(store => store.SaveEventAsync<Planet>(It.Is<PlanetCreatedDomainEvent>()), Times.Once);
+    }
+}
+

--- a/StellarEmpiresTests/Applications/Commands/CreatePlanetCommandHandlerTests.cs
+++ b/StellarEmpiresTests/Applications/Commands/CreatePlanetCommandHandlerTests.cs
@@ -68,7 +68,7 @@ public class CreatePlanetCommandHandlerTests
         await _handler.CreatePlanetAsync(command);
 
         // Assert
-        _mockEventStore.Verify(store => store.SaveEventAsync<Planet>(It.Is<PlanetCreatedDomainEvent>()), Times.Once);
+        _mockEventStore.Verify(store => store.SaveEventAsync<Planet>(It.IsAny<PlanetCreatedDomainEvent>()), Times.Once);
     }
 }
 

--- a/StellarEmpiresTests/Applications/Commands/RenamePlanetCommandHandlerTests.cs
+++ b/StellarEmpiresTests/Applications/Commands/RenamePlanetCommandHandlerTests.cs
@@ -42,7 +42,7 @@ public class RenamePlanetCommandHandlerTests
 		// Arrange
 		var colonizerId = Guid.NewGuid();
 		var planetId = Guid.NewGuid();
-		var planet = new Planet(planetId, "Test Planet", true, colonizerId, _utcNow);
+		var planet = Planet.Create(planetId, "Test Planet", true, colonizerId, _utcNow);
 
 		_planetStateRetrieverMock
 			.Setup(x => x.GetCurrentStateAsync(planetId))
@@ -105,7 +105,7 @@ public class RenamePlanetCommandHandlerTests
 			PlanetName = "New Planet Name"
 		};
 
-		var planet = new Planet(planetId, "Test Planet", true, colonizerId, _utcNow);
+		var planet = Planet.Create(planetId, "Test Planet", true, colonizerId, _utcNow);
 		_planetStateRetrieverMock
 			.Setup(x => x.GetCurrentStateAsync(planetId))
 			.ReturnsAsync(planet);

--- a/StellarEmpiresTests/Domain/EntityTests.cs
+++ b/StellarEmpiresTests/Domain/EntityTests.cs
@@ -7,135 +7,135 @@ namespace StellarEmpires.Tests.Domain;
 [TestFixture]
 public class EntityTests
 {
-    [TearDown]
-    public void Teardown()
-    {
-        DateTimeProvider.ResetUtcNow();
-    }
+	[TearDown]
+	public void Teardown()
+	{
+		DateTimeProvider.ResetUtcNow();
+	}
 
-    [Test]
-    public void Entity_Should_Have_New_Guid_When_Created_Without_Id()
-    {
-        // Arrange & Act
-        var entity = new MockEntity();
+	[Test]
+	public void Entity_Should_Have_New_Guid_When_Created_Without_Id()
+	{
+		// Arrange & Act
+		var entity = new MockEntity();
 
-        // Assert
-        Assert.That(entity.Id, Is.Not.EqualTo(Guid.Empty));
-    }
+		// Assert
+		Assert.That(entity.Id, Is.Not.EqualTo(Guid.Empty));
+	}
 
-    [Test]
-    public void Entity_Should_Have_Specified_Guid_When_Created_With_Id()
-    {
-        // Arrange
-        var guid = Guid.NewGuid();
+	[Test]
+	public void Entity_Should_Have_Specified_Guid_When_Created_With_Id()
+	{
+		// Arrange
+		var guid = Guid.NewGuid();
 
-        // Act
-        var entity = new MockEntity(guid);
+		// Act
+		var entity = new MockEntity(guid);
 
-        // Assert
-        Assert.That(entity.Id, Is.EqualTo(guid));
-    }
+		// Assert
+		Assert.That(entity.Id, Is.EqualTo(guid));
+	}
 
-    [Test]
-    public void Entity_Should_Add_Domain_Event()
-    {
-        // Arrange
-        var entity = new MockEntity();
+	[Test]
+	public void Entity_Should_Add_Domain_Event()
+	{
+		// Arrange
+		var entity = new MockEntity();
 
-        // Act
-        entity.AddDomainEvent();
+		// Act
+		entity.AddDomainEvent();
 
-        // Assert
-        Assert.That(entity.DomainEvents, Has.Count.EqualTo(1));
-        Assert.That(entity.DomainEvents.First(), Is.TypeOf(typeof(MockDomainEvent)));
-    }
+		// Assert
+		Assert.That(entity.DomainEvents, Has.Count.EqualTo(1));
+		Assert.That(entity.DomainEvents.First(), Is.TypeOf(typeof(MockDomainEvent)));
+	}
 
-    [Test]
-    public void Entity_Should_Clear_Domain_Events()
-    {
-        // Arrange
-        var entity = new MockEntity();
-        entity.AddDomainEvent();
+	[Test]
+	public void Entity_Should_Clear_Domain_Events()
+	{
+		// Arrange
+		var entity = new MockEntity();
+		entity.AddDomainEvent();
 
-        // Act
-        entity.ClearDomainEvents();
+		// Act
+		entity.ClearDomainEvents();
 
-        // Assert
-        Assert.That(entity.DomainEvents, Is.Empty);
-    }
+		// Assert
+		Assert.That(entity.DomainEvents, Is.Empty);
+	}
 
-    [Test]
-    public void Entity_Should_Load_And_Apply_Historical_Events()
-    {
-        // Arrange
-        var entity = new MockEntity();
-        var overrideUtcNow = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        DateTimeProvider.SetUtcNow(() => overrideUtcNow);
-        var domainEvent1 = new MockDomainEvent { EntityId = entity.Id };
+	[Test]
+	public void Entity_Should_Load_And_Apply_Historical_Events()
+	{
+		// Arrange
+		var entity = new MockEntity();
+		var overrideUtcNow = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+		DateTimeProvider.SetUtcNow(() => overrideUtcNow);
+		var domainEvent1 = new MockDomainEvent { EntityId = entity.Id };
 
-        overrideUtcNow = new DateTime(2023, 1, 1, 13, 0, 0, DateTimeKind.Utc);
-        DateTimeProvider.SetUtcNow(() => overrideUtcNow);
-        var domainEvent2 = new MockDomainEvent { EntityId = entity.Id };
+		overrideUtcNow = new DateTime(2023, 1, 1, 13, 0, 0, DateTimeKind.Utc);
+		DateTimeProvider.SetUtcNow(() => overrideUtcNow);
+		var domainEvent2 = new MockDomainEvent { EntityId = entity.Id };
 
-        var historicalEvents = new List<IDomainEvent>
-            {
-                domainEvent1,
-                domainEvent2
-            };
+		var historicalEvents = new List<IDomainEvent>
+			{
+				domainEvent1,
+				domainEvent2
+			};
 
-        // Act
-        entity.LoadFromHistory(historicalEvents);
+		// Act
+		entity.LoadFromHistory(historicalEvents);
 
-        // Assert
-        Assert.That(entity.LastEventOccurred, Is.EqualTo(overrideUtcNow));
-        Assert.That(entity.LastEventOccurred, Is.EqualTo(historicalEvents.Last().OccurredOn));
-    }
+		// Assert
+		Assert.That(entity.LastEventOccurred, Is.EqualTo(overrideUtcNow));
+		Assert.That(entity.LastEventOccurred, Is.EqualTo(historicalEvents.Last().OccurredOn));
+	}
 
-    [Test]
-    public void Entity_Should_Set_OccurredOn_To_Overridden_UtcNow()
-    {
-        // Arrange
-        var overrideUtcNow = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-        DateTimeProvider.SetUtcNow(() => overrideUtcNow);
-        var entity = new MockEntity();
+	[Test]
+	public void Entity_Should_Set_OccurredOn_To_Overridden_UtcNow()
+	{
+		// Arrange
+		var overrideUtcNow = new DateTime(2023, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+		DateTimeProvider.SetUtcNow(() => overrideUtcNow);
+		var entity = new MockEntity();
 
-        // Act
-        entity.AddDomainEvent();
+		// Act
+		entity.AddDomainEvent();
 
-        // Assert
-        var domainEvent = (MockDomainEvent)entity.DomainEvents.First();
-        Assert.That(domainEvent.OccurredOn, Is.EqualTo(overrideUtcNow));
-    }
+		// Assert
+		var domainEvent = (MockDomainEvent)entity.DomainEvents.First();
+		Assert.That(domainEvent.OccurredOn, Is.EqualTo(overrideUtcNow));
+	}
 
-    [Test]
-    public void Cloned_Entity_Should_Have_Same_Id()
-    {
-        // Arrange
-        var entity = new MockEntity();
+	[Test]
+	public void Cloned_Entity_Should_Have_Same_Id()
+	{
+		// Arrange
+		var entity = new MockEntity();
 
-        // Act
-        var clonedEntity = entity.Clone();
+		// Act
+		var clonedEntity = entity.Clone();
 
-        // Assert
-        Assert.That(clonedEntity.Id, Is.EqualTo(entity.Id));
-    }
+		// Assert
+		Assert.That(clonedEntity.Id, Is.EqualTo(entity.Id));
+	}
 
-    [Test]
-    public void Entities_With_Same_Id_Should_Be_Equal()
-    {
-        var guid = Guid.NewGuid();
-        var entity1 = new MockEntity(guid);
-        var entity2 = new MockEntity(guid);
-        Assert.That(entity2, Is.EqualTo(entity1));
-        Assert.That(entity1.Equals(entity2), Is.True);
-    }
+	[Test]
+	public void Entities_With_Same_Id_Should_Be_Equal()
+	{
+		var guid = Guid.NewGuid();
+		var entity1 = new MockEntity(guid);
+		var entity2 = new MockEntity(guid);
+		Assert.That(entity2, Is.EqualTo(entity1));
+		Assert.That(entity1.Equals(entity2), Is.True);
+	}
 
-    [Test]
-    public void Entities_With_Different_Ids_Should_Not_Be_Equal()
-    {
-        var entity1 = new MockEntity();
-        var entity2 = new MockEntity();
-        Assert.That(entity2, Is.Not.EqualTo(entity1));
-        Assert.That(entity1.Equals(entity2), Is.False);
-    }
+	[Test]
+	public void Entities_With_Different_Ids_Should_Not_Be_Equal()
+	{
+		var entity1 = new MockEntity();
+		var entity2 = new MockEntity();
+		Assert.That(entity2, Is.Not.EqualTo(entity1));
+		Assert.That(entity1.Equals(entity2), Is.False);
+	}
 }

--- a/StellarEmpiresTests/Infrastructure/EventStore/FileEventStoreTests.cs
+++ b/StellarEmpiresTests/Infrastructure/EventStore/FileEventStoreTests.cs
@@ -85,10 +85,10 @@ public class FileEventStoreTests
 		// Arrange
 		var entityId = Guid.NewGuid();
 		var domainEvents = new List<IDomainEvent>
-						{
-							new MockDomainEvent { EntityId = entityId },
-							new MockDomainEvent { EntityId = entityId }
-						};
+			{
+				new MockDomainEvent { EntityId = entityId },
+				new MockDomainEvent { EntityId = entityId }
+			};
 
 		foreach (var domainEvent in domainEvents)
 		{
@@ -134,7 +134,7 @@ public class FileEventStoreTests
 	{
 		// Arrange
 		var planetId = Guid.NewGuid();
-		var planet = new Planet(planetId, "Earth", false, null, null);
+		var planet = Planet.Create(planetId, "Earth", false, null, null);
 		await _planetStore.SavePlanetAsync(planet);
 
 		var domainEvent = new PlanetColonizedDomainEvent

--- a/StellarEmpiresTests/Infrastructure/EventStore/FileEventStoreTests.cs
+++ b/StellarEmpiresTests/Infrastructure/EventStore/FileEventStoreTests.cs
@@ -153,4 +153,24 @@ public class FileEventStoreTests
 		Assert.That(updatedPlanet.ColonizedBy, Is.EqualTo(domainEvent.PlayerId));
 		Assert.That(updatedPlanet.ColonizedAt, Is.EqualTo(_utcNow));
 	}
+
+	[Test]
+	public async Task SaveEventAsync_ShouldCreateNewPlanet_WhenPlanetDoesNotExist()
+	{
+		// Arrange
+		var planetId = Guid.NewGuid();
+		var domainEvent = new PlanetCreatedDomainEvent
+		{
+			EntityId = planetId,
+			PlanetName = "New Planet"
+		};
+
+		// Act
+		await _eventStore.SaveEventAsync<Planet>(domainEvent);
+
+		// Assert
+		var newPlanet = await _planetStore.GetPlanetByIdAsync(planetId);
+		Assert.That(newPlanet, Is.Not.Null);
+		Assert.That(newPlanet!.Name, Is.EqualTo("New Planet"));
+	}
 }

--- a/StellarEmpiresTests/Infrastructure/PlanetStateRetrieverTests.cs
+++ b/StellarEmpiresTests/Infrastructure/PlanetStateRetrieverTests.cs
@@ -2,10 +2,10 @@
 using StellarEmpires.Domain.Models;
 using StellarEmpires.Domain.Services;
 using StellarEmpires.Events;
+using StellarEmpires.Helpers;
+using StellarEmpires.Infrastructure;
 using StellarEmpires.Infrastructure.EventStore;
 using StellarEmpires.Infrastructure.PlanetStore;
-using StellarEmpires.Infrastructure;
-using StellarEmpires.Helpers;
 
 namespace StellarEmpires.Tests.Infrastructure;
 
@@ -55,7 +55,7 @@ public class PlanetStateRetrieverTests
 	{
 		// Arrange
 		var planetId = Guid.NewGuid();
-		var mockPlanet = new Planet(planetId, "Earth", false, null, null);
+		var mockPlanet = Planet.Create(planetId, "Earth", false, null, null);
 
 		_planetStore
 			.Setup(store => store.GetPlanetByIdAsync(planetId))
@@ -73,7 +73,7 @@ public class PlanetStateRetrieverTests
 	{
 		// Arrange
 		var planetId = Guid.NewGuid();
-		var mockPlanet = new Planet(planetId, "Earth", false, null, null);
+		var mockPlanet = Planet.Create(planetId, "Earth", false, null, null);
 
 		_planetStore
 			.Setup(store => store.GetPlanetByIdAsync(planetId))
@@ -103,7 +103,7 @@ public class PlanetStateRetrieverTests
 		// Arrange
 		var planetId = Guid.NewGuid();
 		var playerId = Guid.NewGuid();
-		var mockPlanet = new Planet(planetId, "Earth", false, null, null);
+		var mockPlanet = Planet.Create(planetId, "Earth", false, null, null);
 
 		var event1 = new PlanetColonizedDomainEvent
 		{

--- a/StellarEmpiresTests/Infrastructure/PlanetStore/FilePlanetStoreTests.cs
+++ b/StellarEmpiresTests/Infrastructure/PlanetStore/FilePlanetStoreTests.cs
@@ -11,9 +11,9 @@ public class FilePlanetStoreTests
 	private MockFileSystem _fileSystem;
 	private FilePlanetStore _planetStore;
 
-    [SetUp]
-    public void Setup()
-    {
+	[SetUp]
+	public void Setup()
+	{
 		_fileSystem = new MockFileSystem();
 		_planetStore = new FilePlanetStore(_fileSystem);
 	}
@@ -32,16 +32,15 @@ public class FilePlanetStoreTests
 	}
 
 	[Test]
-    public async Task SavePlanetAsync_ShouldSavePlanetToFile()
-    {
-        // Arrange
-        var planet = new Planet(Guid.NewGuid(), "Earth", false, null, null);
+	public async Task SavePlanetAsync_ShouldSavePlanetToFile()
+	{
+		// Arrange
+		var planet = new Planet(Guid.NewGuid(), "Earth", false, null, null);
 
-        // Act
-        await _planetStore.SavePlanetAsync(planet);
+		// Act
+		await _planetStore.SavePlanetAsync(planet);
 
 		// Assert
-		
 		Assert.That(_fileSystem.File.Exists("Infrastructure/PlanetStore/planets.json"), Is.True, "The planet file should exist after saving a planet.");
 
 		var fileContent = await _fileSystem.File.ReadAllTextAsync("Infrastructure/PlanetStore/planets.json");
@@ -49,80 +48,86 @@ public class FilePlanetStoreTests
 		Assert.That(planets, Has.Count.EqualTo(1));
 		Assert.That(planets[0].Id, Is.EqualTo(planet.Id));
 		Assert.That(planets[0].Name, Is.EqualTo("Earth"));
-    }
-
-	[Test]
-	public async Task SavePlanetAsync_ShouldThrowException_WhenPlanetAlreadyExists()
-	{
-		// Arrange
-		var planet = new Planet(Guid.NewGuid(), "Earth", false, null, null);
-		await _planetStore.SavePlanetAsync(planet);
-
-		// Act & Assert
-		var exception = Assert.ThrowsAsync<InvalidOperationException>(async () =>
-		{
-			// Try to save the same planet again
-			await _planetStore.SavePlanetAsync(planet);
-		});
-
-		Assert.That(exception.Message, Is.EqualTo("Planet already exists in the list."));
 	}
 
 	[Test]
-    public async Task GetPlanetsAsync_ShouldReturnSavedPlanets()
-    {
-        // Arrange
-        var planet1 = new Planet(Guid.NewGuid(), "Earth", false, null, null);
-        var planet2 = new Planet(Guid.NewGuid(), "Mars", false, null, null);
-        await _planetStore.SavePlanetAsync(planet1);
-        await _planetStore.SavePlanetAsync(planet2);
+	public async Task SavePlanetAsync_ShouldUpdatePlanetState_WhenPlanetAlreadyExists()
+	{
+		// Arrange
+		var planetId = Guid.NewGuid();
+		var planet = new Planet(planetId, "Earth", false, null, null);
+		await _planetStore.SavePlanetAsync(planet);
 
-        // Act
-        var planets = await _planetStore.GetPlanetsAsync();
+		// Act
+		var updatedPlanet = new Planet(planetId, "Mars", true, Guid.NewGuid(), DateTime.UtcNow);
+		await _planetStore.SavePlanetAsync(updatedPlanet);
 
-        // Assert
-        Assert.That(planets, Has.Count.EqualTo(2));
-        Assert.That(planets[0].Name, Is.EqualTo("Earth"));
-        Assert.That(planets[1].Name, Is.EqualTo("Mars"));
-    }
+		// Assert
+		var fileContent = await _fileSystem.File.ReadAllTextAsync("Infrastructure/PlanetStore/planets.json");
+		var planets = JsonSerializer.Deserialize<List<Planet>>(fileContent);
+		Assert.That(planets, Has.Count.EqualTo(1));
+		Assert.That(planets[0].Id, Is.EqualTo(updatedPlanet.Id));
+		Assert.That(planets[0].Name, Is.EqualTo("Mars"));
+		Assert.That(planets[0].IsColonized, Is.True);
+		Assert.That(planets[0].ColonizedBy, Is.EqualTo(updatedPlanet.ColonizedBy));
+		Assert.That(planets[0].ColonizedAt, Is.EqualTo(updatedPlanet.ColonizedAt));
+	}
+
+	[Test]
+	public async Task GetPlanetsAsync_ShouldReturnSavedPlanets()
+	{
+		// Arrange
+		var planet1 = new Planet(Guid.NewGuid(), "Earth", false, null, null);
+		var planet2 = new Planet(Guid.NewGuid(), "Mars", false, null, null);
+		await _planetStore.SavePlanetAsync(planet1);
+		await _planetStore.SavePlanetAsync(planet2);
+
+		// Act
+		var planets = await _planetStore.GetPlanetsAsync();
+
+		// Assert
+		Assert.That(planets, Has.Count.EqualTo(2));
+		Assert.That(planets[0].Name, Is.EqualTo("Earth"));
+		Assert.That(planets[1].Name, Is.EqualTo("Mars"));
+	}
 
 	[Test]
 	public async Task GetPlanetsAsync_ShouldReturnEmptyList_WhenNoPlanetIsSaved()
 	{
-        // Act
-        var planets = await _planetStore.GetPlanetsAsync();
+		// Act
+		var planets = await _planetStore.GetPlanetsAsync();
 
 		// Assert
 		Assert.That(planets, Is.Empty);
 	}
 
 	[Test]
-    public async Task GetPlanetByIdAsync_ShouldReturnCorrectPlanet()
-    {
-        // Arrange
-        var planet1 = new Planet(Guid.NewGuid(), "Earth", false, null, null);
-        var planet2 = new Planet(Guid.NewGuid(), "Mars", false, null, null);
-        await _planetStore.SavePlanetAsync(planet1);
-        await _planetStore.SavePlanetAsync(planet2);
+	public async Task GetPlanetByIdAsync_ShouldReturnCorrectPlanet()
+	{
+		// Arrange
+		var planet1 = new Planet(Guid.NewGuid(), "Earth", false, null, null);
+		var planet2 = new Planet(Guid.NewGuid(), "Mars", false, null, null);
+		await _planetStore.SavePlanetAsync(planet1);
+		await _planetStore.SavePlanetAsync(planet2);
 
-        // Act
-        var result = await _planetStore.GetPlanetByIdAsync(planet1.Id);
+		// Act
+		var result = await _planetStore.GetPlanetByIdAsync(planet1.Id);
 
-        // Assert
-        Assert.That(result, Is.Not.Null);
-        Assert.That(result?.Name, Is.EqualTo("Earth"));
-    }
+		// Assert
+		Assert.That(result, Is.Not.Null);
+		Assert.That(result?.Name, Is.EqualTo("Earth"));
+	}
 
-    [Test]
-    public async Task GetPlanetByIdAsync_ShouldReturnNull_WhenPlanetNotFound()
-    {
-        // Arrange
-        var nonExistentId = Guid.NewGuid();
+	[Test]
+	public async Task GetPlanetByIdAsync_ShouldReturnNull_WhenPlanetNotFound()
+	{
+		// Arrange
+		var nonExistentId = Guid.NewGuid();
 
-        // Act
-        var result = await _planetStore.GetPlanetByIdAsync(nonExistentId);
+		// Act
+		var result = await _planetStore.GetPlanetByIdAsync(nonExistentId);
 
-        // Assert
-        Assert.That(result, Is.Null, "Should return null when the planet does not exist.");
-    }
+		// Assert
+		Assert.That(result, Is.Null, "Should return null when the planet does not exist.");
+	}
 }

--- a/StellarEmpiresTests/Infrastructure/PlanetStore/FilePlanetStoreTests.cs
+++ b/StellarEmpiresTests/Infrastructure/PlanetStore/FilePlanetStoreTests.cs
@@ -22,7 +22,7 @@ public class FilePlanetStoreTests
 	public async Task SavePlanetAsync_ShouldCreateDirectory_WhenDirectoryDoesNotExist()
 	{
 		// Arrange
-		var planet = new Planet(Guid.NewGuid(), "New Planet", false, null, null);
+		var planet = Planet.Create(Guid.NewGuid(), "New Planet", false, null, null);
 
 		// Act
 		await _planetStore.SavePlanetAsync(planet);
@@ -35,7 +35,7 @@ public class FilePlanetStoreTests
 	public async Task SavePlanetAsync_ShouldSavePlanetToFile()
 	{
 		// Arrange
-		var planet = new Planet(Guid.NewGuid(), "Earth", false, null, null);
+		var planet = Planet.Create(Guid.NewGuid(), "Earth", false, null, null);
 
 		// Act
 		await _planetStore.SavePlanetAsync(planet);
@@ -55,11 +55,11 @@ public class FilePlanetStoreTests
 	{
 		// Arrange
 		var planetId = Guid.NewGuid();
-		var planet = new Planet(planetId, "Earth", false, null, null);
+		var planet = Planet.Create(planetId, "Earth", false, null, null);
 		await _planetStore.SavePlanetAsync(planet);
 
 		// Act
-		var updatedPlanet = new Planet(planetId, "Mars", true, Guid.NewGuid(), DateTime.UtcNow);
+		var updatedPlanet = Planet.Create(planetId, "Mars", true, Guid.NewGuid(), DateTime.UtcNow);
 		await _planetStore.SavePlanetAsync(updatedPlanet);
 
 		// Assert
@@ -77,8 +77,8 @@ public class FilePlanetStoreTests
 	public async Task GetPlanetsAsync_ShouldReturnSavedPlanets()
 	{
 		// Arrange
-		var planet1 = new Planet(Guid.NewGuid(), "Earth", false, null, null);
-		var planet2 = new Planet(Guid.NewGuid(), "Mars", false, null, null);
+		var planet1 = Planet.Create(Guid.NewGuid(), "Earth", false, null, null);
+		var planet2 = Planet.Create(Guid.NewGuid(), "Mars", false, null, null);
 		await _planetStore.SavePlanetAsync(planet1);
 		await _planetStore.SavePlanetAsync(planet2);
 
@@ -105,8 +105,8 @@ public class FilePlanetStoreTests
 	public async Task GetPlanetByIdAsync_ShouldReturnCorrectPlanet()
 	{
 		// Arrange
-		var planet1 = new Planet(Guid.NewGuid(), "Earth", false, null, null);
-		var planet2 = new Planet(Guid.NewGuid(), "Mars", false, null, null);
+		var planet1 = Planet.Create(Guid.NewGuid(), "Earth", false, null, null);
+		var planet2 = Planet.Create(Guid.NewGuid(), "Mars", false, null, null);
 		await _planetStore.SavePlanetAsync(planet1);
 		await _planetStore.SavePlanetAsync(planet2);
 

--- a/StellarEmpiresTests/Mocks/MockEntity.cs
+++ b/StellarEmpiresTests/Mocks/MockEntity.cs
@@ -13,7 +13,7 @@ public class MockEntity : Entity
 
 	public void AddDomainEvent()
 	{
-		var domainEvent = new MockDomainEvent{ EntityId = Id };
+		var domainEvent = new MockDomainEvent { EntityId = Id };
 
 		AddDomainEvent(domainEvent);
 	}

--- a/StellarEmpiresTests/WebApi/PlanetsControllerTests.cs
+++ b/StellarEmpiresTests/WebApi/PlanetsControllerTests.cs
@@ -26,9 +26,9 @@ public class PlanetsControllerTests
 		_colonizePlanetCommandHandler = new Mock<IColonizePlanetCommandHandler>();
 		_renamePlanetCommandHandler = new Mock<IRenamePlanetCommandHandler>();
 		_controller = new PlanetsController(
-			_planetStateRetriever.Object, 
-			_planetStore.Object, 
-			_colonizePlanetCommandHandler.Object, 
+			_planetStateRetriever.Object,
+			_planetStore.Object,
+			_colonizePlanetCommandHandler.Object,
 			_renamePlanetCommandHandler.Object);
 	}
 
@@ -37,7 +37,7 @@ public class PlanetsControllerTests
 	{
 		// Arrange
 		var planetId = Guid.NewGuid();
-		var initialPlanet = new Planet(planetId, "Earth", false, null, null);
+		var initialPlanet = Planet.Create(planetId, "Earth", false, null, null);
 		_planetStateRetriever
 			.Setup(x => x.GetInitialStateAsync(planetId))
 			.ReturnsAsync(initialPlanet);
@@ -77,7 +77,7 @@ public class PlanetsControllerTests
 	{
 		// Arrange
 		var planetId = Guid.NewGuid();
-		var currentPlanet = new Planet(planetId, "Mars", true, Guid.NewGuid(), DateTime.UtcNow);
+		var currentPlanet = Planet.Create(planetId, "Mars", true, Guid.NewGuid(), DateTime.UtcNow);
 		_planetStateRetriever
 			.Setup(x => x.GetCurrentStateAsync(planetId))
 			.ReturnsAsync(currentPlanet);
@@ -118,8 +118,8 @@ public class PlanetsControllerTests
 		// Arrange
 		var planets = new List<Planet>
 		{
-			new Planet(Guid.NewGuid(), "Mercury", false, null, null),
-			new Planet(Guid.NewGuid(), "Venus", false, null, null)
+			Planet.Create(Guid.NewGuid(), "Mercury", false, null, null),
+			Planet.Create(Guid.NewGuid(), "Venus", false, null, null)
 		};
 		_planetStore
 			.Setup(x => x.GetPlanetsAsync())
@@ -173,7 +173,7 @@ public class PlanetsControllerTests
 			IsColonized = false
 		};
 
-		var existingPlanet = new Planet(existingPlanetId, "Existing Planet", false, null, null);
+		var existingPlanet = Planet.Create(existingPlanetId, "Existing Planet", false, null, null);
 
 		_planetStore
 			.Setup(store => store.GetPlanetByIdAsync(createPlanetDto.Id))


### PR DESCRIPTION
- Save latest planet (entity) state via `IPlanetStore`, by retrieving latest state and applying the latest event to it
- Create planet entity when saving event if does not exist
- Add a command handler for creating a planet entity